### PR TITLE
Add maturin to cellcast_python dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,10 @@ on the Burn framework. The goal of this project is to modernize (_i.e._ recast)
 established machine learning models in a modern deep learning framework with a
 `WebGPU` backend, enabling easy to install and GPU enabled cell segmentation networks.
 
-## Build `cellcast` from souce
+## Build `cellcast` from source
 
-To install cellcast from source first install the Rust toolchain from [rust-lang.org](https://rust-lang.org/tools/install/).
-Next create an environment (we recommend using `uv`) with the `maturin` development tool. This can be easily done with the
-`uv` tool and this repository's `pyproject.toml`.
+To build and install cellcast from source first install the Rust toolchain from [rust-lang.org](https://rust-lang.org/tools/install/).
+Next create a Python environment (we recommend using `uv`) with the `maturin` development tool in the "cellcast_python" directory:
 
 ```bash
 $ cd cellcast_python
@@ -17,7 +16,7 @@ $ uv venv
 $ uv pip install numpy maturin
 ```
 
-This will create the environment for you with maturin. Next activate your environment and install Rust library with:
+This will create the environment for you with maturin. Next activate your environment and install the cellcast library with:
 
 ```bash
 $ source ./venv/bin/activate
@@ -25,11 +24,15 @@ $ (cellcast_python) maturin develop
 ```
 
 This will compile cellcast as a *non-optimized* binary with debug symbols. This decreases compile time by skipping compiler optimizations
-and retaining debug symbols. If you want the compiler optimizations build cellcast with:
+and retaining debug symbols. To build *optimized* binaries of cellcast you must pass the `--release` flag. Note that this significantly increases
+compilation times to ~6-7 minutes.
 
 ```bash
 $ (cellcast_python) maturin develop --release
 ```
+
+You can also run `uv sync` in the "cellcast_python" directory to create a Python environment and compile cellcast. Note that this installation
+path uses the `--release` flag to compile cellcast, expect longer compile and installation times.
 
 ## Example
 
@@ -43,7 +46,7 @@ from tifffile import imread
 data = imread("path/to/data.tif")
 
 # run stardist inference and produce instance segmentations
-labels = ccm.stardist_2d_versatile_fluo.predict(data)
+labels = ccm.stardist_2d_versatile_fluo.predict(data, gpu=True)
 ```
 
 ## License

--- a/cellcast_python/pyproject.toml
+++ b/cellcast_python/pyproject.toml
@@ -9,10 +9,6 @@ description = "A recast of cell segmentation models built on the Burn deep learn
 authors = [{ name = "cellcast developers" }]
 license = {text = "Unlicense OR MIT"}
 readme = "README.md"
-requires-python = ">=3.9"
-dependencies = [
-    "numpy",
-]
 keywords = ["image-processing", "algorithm", "rust"]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -31,4 +27,15 @@ classifiers = [
     "Programming Language :: Rust",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Image Processing",
+]
+
+requires-python = ">=3.9"
+dependencies = [
+    "numpy",
+]
+
+[dependency-groups]
+# Development tools
+dev = [
+    "maturin",
 ]


### PR DESCRIPTION
This allows a simple `uv sync` to build cellcast, instead of needing to `uv pip install maturin` and then run it manually.

Todos:

- [x] Update the README.md with `uv sync` instructions. Add warning that `--release` is used.